### PR TITLE
pass surveyEngine instance on response changed

### DIFF
--- a/src/components/survey/SurveyView/SurveyView.tsx
+++ b/src/components/survey/SurveyView/SurveyView.tsx
@@ -11,7 +11,7 @@ interface SurveyViewProps {
   survey: Survey;
   languageCode: string;
   onSubmit: (responses: SurveySingleItemResponse[], version: string) => void;
-  onResponsesChanged?: (responses: SurveySingleItemResponse[], version: string) => void;
+  onResponsesChanged?: (responses: SurveySingleItemResponse[], version: string, surveyEngine: SurveyEngineCore) => void;
   prefills?: SurveySingleItemResponse[];
   context?: SurveyContext;
   backBtnText: string;
@@ -42,7 +42,7 @@ const SurveyView: React.FC<SurveyViewProps> = (props) => {
   const onResponsesChanged = () => {
     if (props.onResponsesChanged) {
       const resp = surveyEngine.getResponses();
-      props.onResponsesChanged(resp, props.survey.versionId);
+      props.onResponsesChanged(resp, props.survey.versionId, surveyEngine);
     }
   }
 

--- a/src/components/survey/SurveyView/SurveyView.tsx
+++ b/src/components/survey/SurveyView/SurveyView.tsx
@@ -11,7 +11,7 @@ interface SurveyViewProps {
   survey: Survey;
   languageCode: string;
   onSubmit: (responses: SurveySingleItemResponse[], version: string) => void;
-  onResponsesChanged?: (responses: SurveySingleItemResponse[], version: string, surveyEngine: SurveyEngineCore) => void;
+  onResponsesChanged?: (responses: SurveySingleItemResponse[], version: string, surveyEngine?: SurveyEngineCore) => void;
   prefills?: SurveySingleItemResponse[];
   context?: SurveyContext;
   backBtnText: string;


### PR DESCRIPTION
Add surveyEngine in the onResponseChanged 

This allow an external component to capture the current evaluation context and check expression evaluation (needed for survey_viewer evaluation inspector extension)