### PR TITLE
Subtitle changes

### DIFF
--- a/src/components/survey/SurveySingleItemView/SurveySingleItemView.tsx
+++ b/src/components/survey/SurveySingleItemView/SurveySingleItemView.tsx
@@ -147,7 +147,7 @@ const SurveySingleItemView: React.FC<SurveySingleItemViewProps> = (props) => {
     }
 
     let content = renderFormattedContent(titleComp, props.languageCode, undefined, props.dateLocales ? props.dateLocales : []);
-    const subTitleContent = subTitleComp ? renderFormattedContent(subTitleComp, props.languageCode, 'italic', props.dateLocales ? props.dateLocales : []) : null;
+    const subTitleContent = subTitleComp ? renderFormattedContent(subTitleComp, props.languageCode, 'fst-italic', props.dateLocales ? props.dateLocales : []) : null;
 
     return (
       <div

--- a/src/components/survey/SurveySingleItemView/SurveySingleItemView.tsx
+++ b/src/components/survey/SurveySingleItemView/SurveySingleItemView.tsx
@@ -66,6 +66,8 @@ const SurveySingleItemView: React.FC<SurveySingleItemViewProps> = (props) => {
           switch (component.role) {
             case 'title':
               return null;
+            case 'subtile':
+              return null;
             case 'helpGroup':
               return null;
             case 'footnote':
@@ -122,6 +124,15 @@ const SurveySingleItemView: React.FC<SurveySingleItemViewProps> = (props) => {
 
   // const titleComp = props.renderItem.components ? getItemComponentTranslationByRole(props.renderItem.components.items, 'title', props.languageCode) : undefined;
   const titleComp = getItemComponentByRole(props.renderItem.components?.items, 'title')
+  let subTitleComp = getItemComponentByRole(props.renderItem.components?.items, 'subtitle')
+  // fallback to legacy survey subtitle
+  if (!subTitleComp && titleComp && titleComp.description) {
+    subTitleComp = {
+      key: 'legacy-subtitle',
+      role: 'text',
+      content: titleComp.description,
+    }
+  }
 
   const renderTitleComp = (): React.ReactNode => {
     if (!titleComp) {
@@ -136,8 +147,7 @@ const SurveySingleItemView: React.FC<SurveySingleItemViewProps> = (props) => {
     }
 
     let content = renderFormattedContent(titleComp, props.languageCode, undefined, props.dateLocales ? props.dateLocales : []);
-
-    const description = getLocaleStringTextByCode(titleComp.description, props.languageCode);
+    const subTitleContent = subTitleComp ? renderFormattedContent(subTitleComp, props.languageCode, 'italic', props.dateLocales ? props.dateLocales : []) : null;
 
     return (
       <div
@@ -172,7 +182,8 @@ const SurveySingleItemView: React.FC<SurveySingleItemViewProps> = (props) => {
                 {'*'}
               </span> : null}
           </h5>
-          {description ? <p className="m-0 fst-italic">{description} </p> : null}
+
+          {subTitleContent && <div>{subTitleContent}</div>}
         </div>
 
         {renderHelpGroup()}

--- a/src/components/survey/SurveySingleItemView/stories/SurveySingleItem.stories.tsx
+++ b/src/components/survey/SurveySingleItemView/stories/SurveySingleItem.stories.tsx
@@ -130,7 +130,7 @@ export const Example = () =>
               {
                 key: 't', role: 'title',
                 content: [{ code: 'en', resolvedText: "Question title's content attribute" }],
-                description: [{ code: 'en', resolvedText: "Question title's description attribute" }]
+                description: [{ code: 'en', resolvedText: "Question title's description attribute as fallback" }]
               },
               {
                 key: 'rg', role: 'responseGroup', items: [
@@ -215,6 +215,10 @@ export const Example = () =>
                 key: 't', role: 'title',
                 content: [{ code: 'en', resolvedText: "With help group -> " }],
                 description: [{ code: 'en', resolvedText: "Question title's description attribute" }]
+              },
+              {
+                key: 'st', role: 'subtitle',
+                content: [{ code: 'en', resolvedText: "Question subtitle's content" }],
               },
               {
                 key: 'h', role: 'helpGroup',


### PR DESCRIPTION
Subtitle can now be defined as a separate component (as will be done so by the survey editor). This gives more flexibility in configuring and managing / more consistent with the overall approach. 

Current behaviour is used as a fallback (if no subtitle component defined, but the description is set, it will be used as a subtitle). 